### PR TITLE
Fix incorrect portfolio URL in About page links

### DIFF
--- a/Team10/about/index.html
+++ b/Team10/about/index.html
@@ -23,31 +23,31 @@
         </header>
         <ul>
             <li>
-                <a href="https://cas1xd3.cas.mcmaster.ca/~sita1/portfolio"
+                <a href="https://cs1xd3.cas.mcmaster.ca/~sita1/"
                     >Aaron Sit - Web Developer/Site Owner</a
                 >
             </li>
             <p></p>
             <li>
-                <a href="https://cas1xd3.cas.mcmaster.ca/~joell/portfolio"
+                <a href="https://cs1xd3.cas.mcmaster.ca/~joell/"
                     >Lucas Joel - Web Developer</a
                 >
             </li>
             <p></p>
             <li>
-                <a href="https://cas1xd3.cas.mcmaster.ca/~yuanc37/portfolio"
+                <a href="https://cs1xd3.cas.mcmaster.ca/~yuanc37/"
                     >Jack Yuan - Web Developer</a
                 >
             </li>
             <p></p>
             <li>
-                <a href="https://cas1xd3.cas.mcmaster.ca/~liaoj32/portfolio"
+                <a href="https://cs1xd3.cas.mcmaster.ca/~liaoj32/"
                     >Jim Liao - Web Developer</a
                 >
             </li>
             <p></p>
             <li>
-                <a href="https://cas1xd3.cas.mcmaster.ca/~chiduruh/portfolio"
+                <a href="https://cs1xd3.cas.mcmaster.ca/~chiduruh/"
                     >Harshith Chiduruppa - Web Developer</a
                 >
             </li>


### PR DESCRIPTION
This PR fixes an issue where the links on the About page were pointing to an incorrect portfolio subpath.